### PR TITLE
Open script update

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ Single file build system and a batch build variant.
     - SKSE mod event names
 
 ## **Changelog**
+Version 2.x.x - 2016/MM/DD:
+
+**Core**
+  - Added the ability to use the *Open script* command in views that do not have a compatible syntax. An additional panel, which allows you to select which module's *import* paths should be used, opens up after you enter the (partial) name of the script to look for.
+  - Added an optional *title* setting to module settings. The string value is used when listing modules by name. If this setting does not exist, then the module's key is used instead in listings.
+
 Version 2.1.1 - 2016/04/22:
 
 **Skyrim**

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Version 2.x.x - 2016/MM/DD:
 
 **Core**
   - Added the ability to use the *Open script* command in views that do not have a compatible syntax. An additional panel, which allows you to select which module's *import* paths should be used, opens up after you enter the (partial) name of the script to look for.
+  - Added support for listing all scripts with the *Open script* command by typing in an asterisk (\*) as the only character.
   - Added an optional *title* setting to module settings. The string value is used when listing modules by name. If this setting does not exist, then the module's key is used instead in listings.
 
 Version 2.1.1 - 2016/04/22:

--- a/Source/Core/SublimePapyrus.sublime-settings
+++ b/Source/Core/SublimePapyrus.sublime-settings
@@ -24,11 +24,12 @@
 	{
 		"skyrim":
 		{
-				"compiler":"",
-				"flags":"TESV_Papyrus_Flags.flg",
-				"output": "",
-				"import": [],
-				"arguments": []
+			"title": "The Elder Scrolls V: Skyrim",
+			"compiler":"",
+			"flags":"TESV_Papyrus_Flags.flg",
+			"output": "",
+			"import": [],
+			"arguments": []
 		}
 	}
 }


### PR DESCRIPTION
- Added the ability to use the *Open script* command in views that do not have a compatible syntax. An additional panel, which allows you to select which module's *import* paths should be used, opens up after you enter the (partial) name of the script to look for.
- Added support for listing all scripts with the *Open script* command by typing in an asterisk (\*) as the only character.
- Added an optional *title* setting to module settings. The string value is used when listing modules by name. If this setting does not exist, then the module's key is used instead in listings.