### PR TITLE
Version 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ Settings are located in *Preferences* > *Package Settings* > *SublimePapyrus*.
 
   - ***intelligent_code_completion_function_event_parameters***: Determines if function/event parameters should be included in completions for function/event calls. Default: True
 
-  - ***tooltip_function_parameters***: Determines if a tooltip shows up with information about the parameters of a function/event call that is being edited. Default: True
-    
+  - ***tooltip_function_parameters***: Determines if a tooltip shows up with information about the parameters of the function/event call that is being edited. Default: True
+
+  - ***tooltip_function_docstring***: Determines if a tooltip shows up with the docstring of the function/event call that is being edited. Default: True
+
   - ***tooltip_background_color***: Hex color code of a tooltip's background. Default: #393939
     
   - ***tooltip_body_text_color***: Hex color code of a tooltip's text. Default: #747369
@@ -223,15 +225,15 @@ Single file build system and a batch build variant.
 
 ## **Changelog**
 
-Version 2.6.0 - 2016/MM/DD:
+Version 2.6.0 - 2016/05/DD:
 
 **Core**
-  - Added a setting that toggles displaying docstrings in function call tooltips.
+  - Added a boolean setting for displaying docstrings in function/event call tooltips.
   - Added a warning to the build system framework for when an import path defined in a module's settings does not actually exist on the filesystem.
 
 **Skyrim**
   - Added docstring support to classes representing scriptheaders, functions, events, and properties in the linter.
-  - Added support for displaying docstrings in tooltips for function and event calls.
+  - Added support for displaying docstrings in tooltips for function/event calls.
 
 Version 2.5.0 - 2016/05/05:
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Single file build system and a batch build variant.
 
 ## **Changelog**
 
-Version 2.6.0 - 2016/05/DD:
+Version 2.6.0 - 2016/05/14:
 
 **Core**
   - Added a boolean setting for displaying docstrings in function/event call tooltips.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ Single file build system and a batch build variant.
 
 ## **Changelog**
 
+Version 2.6.0 - 2016/MM/DD:
+
+**Core**
+  - Added setting for toggling displaying docstrings in function call tooltips.
+  - Added a warning to the build system framework for when an import path defined in a module's settings does not actually exist.
+
+**Skyrim**
+  - Added docstring support to scriptheaders, functions, events (not used in scripts according to the CK wiki, but not disallowed by the reference compiler), and properties.
+  - Added support for showing docstrings in tooltips for function and event calls.
+
+
 Version 2.5.0 - 2016/05/05:
 
 **Skyrim**

--- a/README.md
+++ b/README.md
@@ -226,13 +226,12 @@ Single file build system and a batch build variant.
 Version 2.6.0 - 2016/MM/DD:
 
 **Core**
-  - Added setting for toggling displaying docstrings in function call tooltips.
-  - Added a warning to the build system framework for when an import path defined in a module's settings does not actually exist.
+  - Added a setting that toggles displaying docstrings in function call tooltips.
+  - Added a warning to the build system framework for when an import path defined in a module's settings does not actually exist on the filesystem.
 
 **Skyrim**
-  - Added docstring support to scriptheaders, functions, events (not used in scripts according to the CK wiki, but not disallowed by the reference compiler), and properties.
-  - Added support for showing docstrings in tooltips for function and event calls.
-
+  - Added docstring support to classes representing scriptheaders, functions, events (not used in scripts according to the CK wiki, but not disallowed by the reference compiler), and properties.
+  - Added support for displaying docstrings in tooltips for function and event calls.
 
 Version 2.5.0 - 2016/05/05:
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Version 2.6.0 - 2016/MM/DD:
   - Added a warning to the build system framework for when an import path defined in a module's settings does not actually exist on the filesystem.
 
 **Skyrim**
-  - Added docstring support to classes representing scriptheaders, functions, events (not used in scripts according to the CK wiki, but not disallowed by the reference compiler), and properties.
+  - Added docstring support to classes representing scriptheaders, functions, events, and properties in the linter.
   - Added support for displaying docstrings in tooltips for function and event calls.
 
 Version 2.5.0 - 2016/05/05:

--- a/Source/Core/Plugin.py
+++ b/Source/Core/Plugin.py
@@ -261,6 +261,9 @@ class SublimePapyrusCompileScriptCommand(sublime_plugin.WindowCommand):
 								t = filePath.lower()
 								if not all(t != k.lower() for k in imports) and settings.get("batch_compilation_warning", True) and not sublime.ok_cancel_dialog("Are you sure you want to batch compile all script sources in \"%s\"?\n\nThis folder is one of the import folders and may contain script sources that are a part of the base game. Compiling said script sources could lead to unintended behavior if they have been modified." % filePath):
 									return
+							for path in imports:
+								if not os.path.isdir(path):
+									return ShowMessage("'%s' is not a path that exists." % path)
 							imports = ";".join(imports)
 						else:
 							return ShowMessage("The import path(s) setting has to be a list of strings.")

--- a/Source/Core/Plugin.py
+++ b/Source/Core/Plugin.py
@@ -263,7 +263,7 @@ class SublimePapyrusCompileScriptCommand(sublime_plugin.WindowCommand):
 									return
 							for path in imports:
 								if not os.path.isdir(path):
-									return ShowMessage("'%s' is not a path that exists." % path)
+									return ShowMessage("The import path '%s' does not exist on the filesystem." % path)
 							imports = ";".join(imports)
 						else:
 							return ShowMessage("The import path(s) setting has to be a list of strings.")

--- a/Source/Core/SublimePapyrus.sublime-settings
+++ b/Source/Core/SublimePapyrus.sublime-settings
@@ -8,6 +8,7 @@
 	"intelligent_code_completion": true,
 	"intelligent_code_completion_function_event_parameters": true,
 	"tooltip_function_parameters": true,
+	"tooltip_function_docstring": true,
 	"tooltip_background_color": "#393939",
 	"tooltip_body_text_color": "#747369",
 	"tooltip_font_size": "12",


### PR DESCRIPTION
**Core**
- Added a boolean setting for displaying docstrings in function/event call tooltips.
- Added a warning to the build system framework for when an import path defined in a module's settings does not actually exist on the filesystem.

**Skyrim**
- Added docstring support to classes representing scriptheaders, functions, events, and properties in the linter.
- Added support for displaying docstrings in tooltips for function/event calls.