### PR TITLE
Array find fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Version 2.6.1 - 2016/MM/DD:
 
 **Skyrim**
   - Fixed issue that caused errors when attempting to call *Find* and *RFind* functions on arrays of base types.
+  - The name of the first argument in the completions for the *Find* and *RFind* functions of arrays now changes based on the array's element type (abElement, afElement, aiElement, asElement, or akElement).
 
 Version 2.6.0 - 2016/05/14:
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ Single file build system and a batch build variant.
 
 ## **Changelog**
 
+Version 2.6.1 - 2016/MM/DD:
+
+**Skyrim**
+  - Fixed issue that caused errors when attempting to call *Find* and *RFind* functions on arrays of base types.
+
 Version 2.6.0 - 2016/05/14:
 
 **Core**

--- a/Source/Modules/Skyrim/Linter.py
+++ b/Source/Modules/Skyrim/Linter.py
@@ -2218,8 +2218,12 @@ class Semantic(SharedResources):
 					self.Abort("This script does not have a function/event called '%s'." % node.data.name.value)
 			elif expected and expected.type:
 				if expected.array:
-					script = self.GetCachedScript(expected.type)
-					if script:
+					validArrayType = None
+					if expected.type == self.KW_BOOL or expected.type == self.KW_FLOAT or expected.type == self.KW_INT or expected.type == self.KW_STRING:
+						validArrayType = True
+					else:
+						validArrayType = self.GetCachedScript(expected.type)
+					if validArrayType:
 						funcName = node.data.name.value.upper()
 						if funcName == "FIND":
 							func = Statement(self.STAT_FUNCTIONDEF, 0, FunctionDef("INT", "Int", False, "FIND", "Find", [ParameterDef(expected.type, expected.type.capitalize(), False, "AKELEMENT", "akElement", None), ParameterDef("INT", "Int", False, "AISTARTINDEX", "aiStartIndex", Node(self.NODE_EXPRESSION, ExpressionNode(Node(self.NODE_CONSTANT, ConstantNode(Token(self.INT, "0", 0, 0))))))], [self.KW_NATIVE]))							

--- a/Source/Modules/Skyrim/Plugin.py
+++ b/Source/Modules/Skyrim/Plugin.py
@@ -221,7 +221,8 @@ class EventListener(sublime_plugin.EventListener):
 															if result.type != sem.KW_SELF:
 																try:
 																	script = sem.GetCachedScript(result.type)
-																	func = script.functions.get(name, None)
+																	if script:
+																		func = script.functions.get(name, None)
 																except Linter.SemanticError as e:
 																	return
 															else:
@@ -961,7 +962,8 @@ h1 {
 												if result.type != sem.KW_SELF:
 													try:
 														script = sem.GetCachedScript(result.type)
-														func = script.functions.get(name, None)
+														if script:
+															func = script.functions.get(name, None)
 													except Linter.SemanticError as e:
 														return
 												else:

--- a/Source/Modules/Skyrim/Plugin.py
+++ b/Source/Modules/Skyrim/Plugin.py
@@ -832,8 +832,17 @@ h1 {
 											return completions
 										elif result.array:
 											typ = result.type.capitalize()
-											completions.append(("find\tint func.", "Find(${1:%s akElement}, ${2:Int aiStartIndex = 0})" % typ,))
-											completions.append(("rfind\tint func.", "RFind(${1:%s akElement}, ${2:Int aiStartIndex = -1})" % typ,))
+											elementIdentifier = "akElement"
+											if typ == "Bool":
+												elementIdentifier = "abElement"
+											elif typ == "Float":
+												elementIdentifier = "afElement"
+											elif typ == "Int":
+												elementIdentifier = "aiElement"
+											elif typ == "String":
+												elementIdentifier = "asElement"
+											completions.append(("find\tint func.", "Find(${1:%s %s}, ${2:Int aiStartIndex = 0})" % (typ, elementIdentifier),))
+											completions.append(("rfind\tint func.", "RFind(${1:%s %s}, ${2:Int aiStartIndex = -1})" % (typ, elementIdentifier),))
 											completions.append(("length\tkeyword", "Length",))
 											return completions
 										else:


### PR DESCRIPTION
**Skyrim**
  - Fixed issue that caused errors when attempting to call *Find* and *RFind* functions on arrays of base types.
  - The name of the first argument in the completions for the *Find* and *RFind* functions of arrays now changes based on the array's element type (abElement, afElement, aiElement, asElement, or akElement).